### PR TITLE
Clean up ResizeObservers on Timeline unmount

### DIFF
--- a/src/year2/components/Timeline.tsx
+++ b/src/year2/components/Timeline.tsx
@@ -38,11 +38,11 @@ export function Timeline ({ memories }: TimelineProps): JSX.Element {
     [key: number]: number
   }>({})
 
-  const observers = React.useRef(new Map<number, ResizeObserver>());
+  const observers = React.useRef(new Map<number, ResizeObserver>())
 
   React.useEffect(() => {
     return () => {
-      observers.current?.forEach((observer) => observer.disconnect());
+      observers.current?.forEach((observer) => observer.disconnect())
     }
   })
 
@@ -68,9 +68,9 @@ export function Timeline ({ memories }: TimelineProps): JSX.Element {
                       return itemHeights
                     }
                   })
-                });
-                observer.observe(node);
-                observers.current?.set(i, observer);
+                })
+                observer.observe(node)
+                observers.current?.set(i, observer)
               }
             }}
             verticalOffset={(itemHeights[i - 1] ?? 0) / 3}

--- a/src/year2/components/Timeline.tsx
+++ b/src/year2/components/Timeline.tsx
@@ -38,6 +38,14 @@ export function Timeline ({ memories }: TimelineProps): JSX.Element {
     [key: number]: number
   }>({})
 
+  const observers = React.useRef(new Map<number, ResizeObserver>());
+
+  React.useEffect(() => {
+    return () => {
+      observers.current?.forEach((observer) => observer.disconnect());
+    }
+  })
+
   return (
     <div className={classes['timeline-root']}>
       <ul className={classes['timeline-items']}>
@@ -46,11 +54,11 @@ export function Timeline ({ memories }: TimelineProps): JSX.Element {
             key={i}
             ref={(node) => {
               if (node != null) {
-                new ResizeObserver(([entry]) => {
-                  // console.log('resize')
+                const observer = new ResizeObserver(([entry]) => {
                   setItemHeights((itemHeights) => {
-                    // console.log(entry.borderBoxSize)
                     const newHeight = entry.borderBoxSize[0].blockSize
+                    // Only dispatch an update if the height changed.
+                    // This prevents an infinite loop of setState calls
                     if (newHeight !== itemHeights[i]) {
                       return {
                         ...itemHeights,
@@ -60,7 +68,9 @@ export function Timeline ({ memories }: TimelineProps): JSX.Element {
                       return itemHeights
                     }
                   })
-                }).observe(node)
+                });
+                observer.observe(node);
+                observers.current?.set(i, observer);
               }
             }}
             verticalOffset={(itemHeights[i - 1] ?? 0) / 3}


### PR DESCRIPTION
Fixes the following error:

Warning: Can't perform a React state update on an unmounted component. This is a no-op, but it indicates a memory leak in your application. To fix, cancel all subscriptions and asynchronous tasks in a useEffect cleanup function.
    at Timeline (http://localhost:5173/src/year2/components/Timeline.tsx:20:3)
    at div
    at Home
    at div
    at PageWrapper (http://localhost:5173/src/year2/components/PageWrapper.tsx:19:3)